### PR TITLE
修复几个问题
1.gemini要求请求的每条消息content不为空
2.保存上下文时，需要严格验证函数调用是否成对
3.发送时，验证上下文函数调用是否成对


对历史记录的toolcall验证参考:
https://github.com/run-llama/llama_index/issues/13715
https://github.com/run-llama/llama_index/pull/16214

### DIFF
--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -175,7 +175,15 @@ class ConversationManager:
             if record["role"] == "user":
                 temp_contexts.append(f"User: {record['content']}")
             elif record["role"] == "assistant":
-                temp_contexts.append(f"Assistant: {record['content']}")
+                if "content" in record and record["content"]:
+                    temp_contexts.append(f"Assistant: {record['content']}")
+                elif "tool_calls" in record:
+                    tool_calls_str = json.dumps(
+                        record["tool_calls"], ensure_ascii=False
+                    )
+                    temp_contexts.append(f"Assistant: [函数调用] {tool_calls_str}")
+                else:
+                    temp_contexts.append("Assistant: [未知的内容]")
                 contexts.insert(0, temp_contexts)
                 temp_contexts = []
 

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -146,12 +146,10 @@ class ProviderGoogleGenAI(Provider):
         for message in payloads["messages"]:
             if message["role"] == "user":
                 if isinstance(message["content"], str):
-                    if not message["content"]:
-                        message["content"] = ""
-
-                    google_genai_conversation.append(
-                        {"role": "user", "parts": [{"text": message["content"]}]}
-                    )
+                    if message["content"]:
+                        google_genai_conversation.append(
+                            {"role": "user", "parts": [{"text": message["content"]}]}
+                        )
                 elif isinstance(message["content"], list):
                     # images
                     parts = []
@@ -175,11 +173,10 @@ class ProviderGoogleGenAI(Provider):
 
             elif message["role"] == "assistant":
                 if "content" in message:
-                    if not message["content"]:
-                        message["content"] = ""
-                    google_genai_conversation.append(
-                        {"role": "model", "parts": [{"text": message["content"]}]}
-                    )
+                    if message["content"]:
+                        google_genai_conversation.append(
+                            {"role": "model", "parts": [{"text": message["content"]}]}
+                        )
                 elif "tool_calls" in message:
                     # tool calls in the last turn
                     parts = []


### PR DESCRIPTION
和上一个pr修复的问题相同，实现完全不同

### Motivation

修复上一个pr的各个问题

### Modifications

修改了history显示的内容，在存储上下文时对toolcall进行检验，在读取上下文时对toolcall进行检验


